### PR TITLE
fix: slider-bug in firefox

### DIFF
--- a/files/nutshell/scss/base/_grid.scss
+++ b/files/nutshell/scss/base/_grid.scss
@@ -27,7 +27,7 @@ $grid__columns:         12 !default;
 // general row-class
 .row {
   display: grid;
-  grid-template-columns: repeat(var(--grid__columns), 1fr);
+  grid-template-columns: repeat(var(--grid__columns), minmax(0, 1fr));
   grid-column-gap: var(--grid__gutter);
   grid-auto-columns: 1fr;
 


### PR DESCRIPTION
Problem: when a slider is inside a column, that width gets calculated wrong
Solution: use minmax(0, 1fr) instead of just 1fr